### PR TITLE
BUG: Fix a nasty bug when squeezing an array.

### DIFF
--- a/cyarray/carray.pyx
+++ b/cyarray/carray.pyx
@@ -45,7 +45,7 @@ logger = logging.getLogger()
 
 # 'importing' some Numpy C-api functions.
 cdef extern from "numpy/arrayobject.h":
-    cdef void  import_array()
+    cdef void  _import_array()
 
     ctypedef struct PyArrayObject:
         char  *data
@@ -66,7 +66,7 @@ cdef extern from "stdlib.h":
      void *memcpy(void *dst, void *src, long n) nogil
 
 # numpy module initialization call
-import_array()
+_import_array()
 
 cdef inline long aligned(long n, int item_size) nogil:
     """Align `n` items each having size (in bytes) `item_size` to
@@ -110,9 +110,10 @@ cdef void* _aligned_realloc(void *existing, size_t bytes, size_t old_size) nogil
 
     """
     cdef void* result = _aligned_malloc(bytes)
+    cdef size_t copy_size = min(bytes, old_size)
 
     # Copy everything from the old to the new and free the old.
-    memcpy(<void*>result, <void*>existing, old_size)
+    memcpy(<void*>result, <void*>existing, copy_size)
     aligned_free(<void*>existing)
 
     return result

--- a/cyarray/carray.pyx.mako
+++ b/cyarray/carray.pyx.mako
@@ -118,9 +118,10 @@ cdef void* _aligned_realloc(void *existing, size_t bytes, size_t old_size) nogil
 
     """
     cdef void* result = _aligned_malloc(bytes)
+    cdef size_t copy_size = min(bytes, old_size)
 
     # Copy everything from the old to the new and free the old.
-    memcpy(<void*>result, <void*>existing, old_size)
+    memcpy(<void*>result, <void*>existing, copy_size)
     aligned_free(<void*>existing)
 
     return result

--- a/cyarray/tests/test_carray.py
+++ b/cyarray/tests/test_carray.py
@@ -147,9 +147,6 @@ class TestLongArray(unittest.TestCase):
         self.assertRaises(ValueError, la.set_data, numpy.arange(10))
 
     def test_squeeze(self):
-        """
-        Tests the squeeze function.
-        """
         la = LongArray(5)
         la.append(4)
 
@@ -173,6 +170,21 @@ class TestLongArray(unittest.TestCase):
         self.assertEqual(len(la.get_npy_array()), 0)
         self.assertEqual(la.alloc >= la.length, True)
         del la  # This should work and not segfault.
+
+    def test_squeeze_large_array_should_not_segfault(self):
+        # Given
+        la = LongArray(10)
+        la.set_data(numpy.zeros(10, dtype=int))
+        la.reserve(100000)
+
+        # When
+        la.squeeze()
+        la.reserve(1000)
+
+        # Then
+        self.assertEqual(la.length, 10)
+        numpy.testing.assert_array_almost_equal(la.get_npy_array(), 0)
+        self.assertEqual(la.alloc >= la.length, True)
 
     def test_reset(self):
         """


### PR DESCRIPTION
The memcpy was copying the original size when it should copy the minimum
size from old to new.