### PR TITLE
Remove pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[build-system]
-requires = ['Cython>=0.20', 'numpy', 'mako', 'setuptools', 'wheel']


### PR DESCRIPTION
This causes more problems as pip's build isolation tends to lead to
strange errors as when cyarray is built and installed its dependencies
are installed into an isolated environment leading to strange looking
issues for unsuspecting users.