### PR TITLE
Add pyproject.toml again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 # command to install dependencies
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
 
   matrix:
-    - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python38-x64"
 
 install:
   # We need wheel installed to build wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+    "oldest-supported-numpy",
+    "Cython>=0.20",
+    "mako"
+]


### PR DESCRIPTION
This should work better with the oldest-supported-numpy package. Also
remove the python 2.x builds from CI and add 3.8.