### PR TITLE
Add minimum version for setuptools.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "wheel",
-    "setuptools",
+    "wheel>=0.29.0",
+    "setuptools>=42.0.0",
     "oldest-supported-numpy",
     "Cython>=0.20",
     "mako"


### PR DESCRIPTION
This is for older Python versions which may have old versions of
setuptools which do not support `setuptools.build_meta`.